### PR TITLE
Use tripleo-ui review and patchset# instead of short commit

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -3,16 +3,18 @@
 set -ex
 
 REPONAME="tripleo-ui"
-REPO="https://github.com/openstack/$REPONAME"
-COMMIT=`awk '/%global commit/ { print $3 }' *spec`
-SHORT_COMMIT=${COMMIT:0:7}
-TARBALL="tripleo-ui-deps-$SHORT_COMMIT.tar.gz"
+REPO="https://review.openstack.org/p/openstack/$REPONAME"
+REVIEW=$(awk '/%global review/ { print $3 }' *spec)
+REVIEW2=$(awk '/%global review/ { print substr($3,length($3)-1,2)}' *spec)
+PATCHSET=$(awk '/%global patchset/ { print $3 }' *spec)
+TARBALL="tripleo-ui-deps-$REVIEW.$PATCHSET.tar.gz"
 
 function generate_archive() {
     rm -rf $REPONAME
     git clone $REPO
     pushd $REPONAME
-        git checkout $SHORT_COMMIT
+        git fetch origin refs/changes/$REVIEW2/$REVIEW/$PATCHSET
+        git checkout FETCH_HEAD
         npm install
         tar czf $TARBALL node_modules
         mv $TARBALL ..

--- a/openstack-tripleo-ui-deps.spec
+++ b/openstack-tripleo-ui-deps.spec
@@ -1,8 +1,8 @@
 # This package won't generate useful debuginfo
 %global debug_package %{nil}
 %global sname openstack-tripleo-ui-deps
-%global commit e1adf4c78e59fe3911c7429f6a321ea4c98640f9
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global review 535323
+%global patchset 4
 
 Name:           %{sname}
 Version:        8
@@ -13,7 +13,7 @@ URL:            http://tripleo.org
 
 # See companion script create_tarball.sh to generate
 # source tarball
-Source0:        tripleo-ui-deps-%{shortcommit}.tar.gz
+Source0:        tripleo-ui-deps-%{review}.%{patchset}.tar.gz
 
 # Cannot build as noarch until nodejs is built from aarch64 in CBS
 ExclusiveArch: x86_64


### PR DESCRIPTION
This allows building ui-deps RPM before upstream change is merged as discussed in
http://lists.openstack.org/pipermail/openstack-dev/2018-January/126412.html