### PR TITLE
Remove coffee from __brp_mangle_shebangs

### DIFF
--- a/openstack-tripleo-ui-deps.spec
+++ b/openstack-tripleo-ui-deps.spec
@@ -4,6 +4,8 @@
 %global review 601626
 %global patchset 3
 
+%global __brp_mangle_shebangs_exclude coffee
+
 Name:           %{sname}
 Version:        10
 Release:        1%{?dist}


### PR DESCRIPTION
In fedora, when building tripleo-ui-deps, the automatic shebangs
macro is adding /usr/bin/./node_modules/.bin/coffee because of a
shebang in a test script from one of the modules included in
tripleo-ui-deps. This patch is removing the coffee binary from
the shebangs automation.